### PR TITLE
Fix a padding bug while switching between tabs with default skin

### DIFF
--- a/content/treestyletab/treestyletab.css
+++ b/content/treestyletab/treestyletab.css
@@ -225,6 +225,10 @@ tabs.tabbrowser-tabs[treestyletab-tabbar-position="left"][treestyletab-invert-sc
   .tabbrowser-arrowscrollbox
   > scrollbox {
 	direction: rtl;
+	
+	/* Fix a padding bug while switching between tabs with default skin */
+	margin-left: -1px !important;
+	padding-left: 1px !important;
 }
 tabs.tabbrowser-tabs[treestyletab-tabbar-position="left"][treestyletab-invert-scrollbar="true"]
   .tabbrowser-arrowscrollbox


### PR DESCRIPTION
The bug is present when default skin is selected for TST sidebar and scrollbar is set to be on the left side.

![bug](http://i.imgur.com/3x2sJAy.gif)