### PR TITLE
Add a secret pref to disable tab dragging animation

### DIFF
--- a/defaults/preferences/treestyletab.js
+++ b/defaults/preferences/treestyletab.js
@@ -6,6 +6,7 @@
  */
 pref("extensions.treestyletab.animation.indent.duration",   200);
 pref("extensions.treestyletab.animation.collapse.duration", 150);
+pref("extensions.treestyletab.animation.drag.enabled",      true);
 
 /**
  * Size of resizable tab bar. They are completely ignored if "Tabs on Top"

--- a/modules/base.js
+++ b/modules/base.js
@@ -2507,6 +2507,8 @@ var TreeStyleTabBase = inherit(TreeStyleTabConstants, {
 				return this.indentDuration = value;
 			case 'extensions.treestyletab.animation.collapse.duration':
 				return this.collapseDuration = value;
+			case 'extensions.treestyletab.animation.drag.enabled':
+				return this.dragAnimation = value;
 
 			case 'extensions.treestyletab.twisty.expandSensitiveArea':
 				return this.shouldExpandTwistyArea = value;

--- a/modules/tabbarDNDObserver.js
+++ b/modules/tabbarDNDObserver.js
@@ -931,17 +931,19 @@ try{
 
 		let draggedTab = aEvent.dataTransfer && aEvent.dataTransfer.mozGetDataAt(TAB_DROP_TYPE, 0);
 		let dragOverTab = sv.getTabFromEvent(aEvent) || sv.getTabFromTabbarEvent(aEvent) || aEvent.target;
-		b.ownerDocument.defaultView['piro.sakura.ne.jp'].tabsDragUtils
-			.processTabsDragging(aEvent, {
-				canDropOnSelf : !dragOverTab || !dragOverTab.pinned,
-				isVertical : (
-					b.ownerDocument.defaultView['piro.sakura.ne.jp'].tabsDragUtils.isVertical(b.tabContainer) &&
-					(
-						(draggedTab && !draggedTab.pinned) ||
-						!utils.getTreePref('pinnedTab.faviconized')
+		if (sv.dragAnimation){
+			b.ownerDocument.defaultView['piro.sakura.ne.jp'].tabsDragUtils
+				.processTabsDragging(aEvent, {
+					canDropOnSelf : !dragOverTab || !dragOverTab.pinned,
+					isVertical : (
+						b.ownerDocument.defaultView['piro.sakura.ne.jp'].tabsDragUtils.isVertical(b.tabContainer) &&
+						(
+							(draggedTab && !draggedTab.pinned) ||
+							!utils.getTreePref('pinnedTab.faviconized')
+						)
 					)
-				)
-			});
+				});
+		}
 
 		/**
 		 * We must calculate drop action after tabsDragUtils.processTabsDragging(),
@@ -1001,14 +1003,16 @@ try{
 			indicatorTab.getAttribute(sv.kDROP_POSITION) != dropPosition) {
 			this.clearDropPosition();
 			indicatorTab.setAttribute(sv.kDROP_POSITION, dropPosition);
-			if (b.ownerDocument.defaultView['piro.sakura.ne.jp'].tabsDragUtils
+			if (sv.dragAnimation){
+				if (b.ownerDocument.defaultView['piro.sakura.ne.jp'].tabsDragUtils
 					.canAnimateDraggedTabs(aEvent)) {
-				let newOpacity = dropPosition == 'self' ? 0.35 : 0.75 ; // to prevent the dragged tab hides the drop target itself
-				this.window['piro.sakura.ne.jp'].tabsDragUtils.getDraggedTabs(aEvent).forEach(function(aTab) {
-					if (!('__treestyletab__opacityBeforeDragged' in aTab))
-						aTab.__treestyletab__opacityBeforeDragged = aTab.style.opacity || '';
-					aTab.style.opacity = newOpacity;
-				});
+					let newOpacity = dropPosition == 'self' ? 0.35 : 0.75 ; // to prevent the dragged tab hides the drop target itself
+					this.window['piro.sakura.ne.jp'].tabsDragUtils.getDraggedTabs(aEvent).forEach(function(aTab) {
+						if (!('__treestyletab__opacityBeforeDragged' in aTab))
+							aTab.__treestyletab__opacityBeforeDragged = aTab.style.opacity || '';
+						aTab.style.opacity = newOpacity;
+					});
+				}
 			}
 		}
 


### PR DESCRIPTION
Adds a secret preference "extensions.treestyletab.animation.drag.enabled" to toggle tab dragging animation (true by default).
As discussed in https://github.com/piroor/treestyletab/issues/499 , the animations make it hard to drag/drop tabs or trees properly. The pull request https://github.com/wanabe/treestyletab/commit/ffb74310991c848059d8ac23b86c923367dd8d87 proposed to add a secret pref to disable them, but unfortunately it wasn't accepted. I would like this pref to be included in Tree Style Tabs for Pale Moon.